### PR TITLE
fix: won't show red alerts for 1-2 seconds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -279,10 +279,16 @@ export default class Proctor {
     this.proctoringInitialised = true;
     if (this.config.fullScreen.enabled) {
       requestFullScreen();
-      detectFullScreen({
-        onFullScreenDisabled: this.handleFullScreenDisabled.bind(this),
-        onFullScreenEnabled: this.handleFullScreenEnabled.bind(this),
-      });
+      const handleFullScreenChange = () => {
+        if (isFullScreen()) {
+          detectFullScreen({
+            onFullScreenDisabled: this.handleFullScreenDisabled.bind(this),
+            onFullScreenEnabled: this.handleFullScreenEnabled.bind(this),
+          });
+          document.removeEventListener('fullscreenchange', handleFullScreenChange);
+        }
+      };
+      document.addEventListener('fullscreenchange', handleFullScreenChange);
     }
 
     if (this.config.tabSwitch.enabled) {

--- a/src/index.js
+++ b/src/index.js
@@ -260,6 +260,7 @@ export default class Proctor {
     this.compatibilityCheckInterval = null;
     this.initializeProctoring = this.initializeProctoring.bind(this);
     this.runCompatibilityChecks = this.runCompatibilityChecks.bind(this);
+    this.initialFullScreen = false;
     setupAlert();
     addFullscreenKeyboardListener();
     setupCompatibilityCheckModal(() => {
@@ -278,17 +279,10 @@ export default class Proctor {
   initializeProctoring() {
     this.proctoringInitialised = true;
     if (this.config.fullScreen.enabled) {
-      requestFullScreen();
-      const handleFullScreenChange = () => {
-        if (isFullScreen()) {
-          detectFullScreen({
-            onFullScreenDisabled: this.handleFullScreenDisabled.bind(this),
-            onFullScreenEnabled: this.handleFullScreenEnabled.bind(this),
-          });
-          document.removeEventListener('fullscreenchange', handleFullScreenChange);
-        }
-      };
-      document.addEventListener('fullscreenchange', handleFullScreenChange);
+      detectFullScreen({
+        onFullScreenDisabled: this.handleFullScreenDisabled.bind(this),
+        onFullScreenEnabled: this.handleFullScreenEnabled.bind(this),
+      });
     }
 
     if (this.config.tabSwitch.enabled) {
@@ -557,8 +551,13 @@ export default class Proctor {
   }
 
   handleFullScreenDisabled() {
-    this.handleViolation(VIOLATIONS.fullScreen);
-    this.callbacks.onFullScreenDisabled();
+    if (!this.initialFullScreen) {
+      requestFullScreen();
+      this.initialFullScreen = true;
+    } else {
+      this.handleViolation(VIOLATIONS.fullScreen);
+      this.callbacks.onFullScreenDisabled();
+    }
   }
 
   handleFullScreenEnabled() {


### PR DESCRIPTION
# Description
This PR includes : 
- Addition of callback before enabling the detectFullScreen feature.

# Screen cast
## Before adding callback
[Screencast from 22-10-24 03:24:52 PM IST.webm](https://github.com/user-attachments/assets/8dc51299-eb06-4132-aedc-4a3307351cc1)


## After callback
[Screencast from 22-10-24 03:22:08 PM IST.webm](https://github.com/user-attachments/assets/29e35f2c-cb82-43c0-96d9-75d87cbf214f)

