### PR TITLE
add : allow two content type headers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import {
   MAX_EVENTS_BEFORE_SEND,
   SNAPSHOT_SCREENSHOT_FREQUENCY,
   VIOLATIONS,
-  DEFAULT_HEADERS_CONTENT_TYPE,
+  HEADER_CONTENT_TYPES,
 } from './utils/constants';
 import { dispatchGenericViolationEvent, dispatchViolationEvent } from './utils/events';
 import {
@@ -65,7 +65,7 @@ export default class Proctor {
     };
     this.headerOptions = {
       csrfToken: null,
-      contentType: DEFAULT_HEADERS_CONTENT_TYPE,
+      contentType: HEADER_CONTENT_TYPES.urlEncoded,
       ...headerOptions,
     };
     this.compatibilityCheckConfig = {
@@ -719,17 +719,28 @@ export default class Proctor {
     if (this.recordedViolationEvents.length === 0) return;
 
     const url = new URL(this.eventsConfig.endpoint, this.baseUrl).toString();
-    const payload = new URLSearchParams({
-      events: JSON.stringify(this.recordedViolationEvents),
-    });
+
+    let body;
+    const headers = {
+      'Content-Type': this.headerOptions.contentType,
+      'X-CSRF-TOKEN': this.headerOptions.csrfToken,
+    };
+
+    if (this.headerOptions.contentType === HEADER_CONTENT_TYPES.json) {
+      body = JSON.stringify({ events: this.recordedViolationEvents });
+    } else if (this.headerOptions.contentType === HEADER_CONTENT_TYPES.urlEncoded) {
+      body = new URLSearchParams({
+        events: JSON.stringify(this.recordedViolationEvents),
+      }).toString();
+    } else {
+      console.error('Unsupported content type:', this.headerOptions.contentType);
+      return;
+    }
 
     fetch(url, {
       method: 'POST',
-      headers: {
-        'Content-Type': this.headerOptions.contentType,
-        'X-CSRF-TOKEN': this.headerOptions.csrfToken,
-      },
-      body: payload.toString(),
+      headers,
+      body,
     }).then(() => {
       this.recordedViolationEvents = [];
     }).catch((error) => {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -23,4 +23,8 @@ export const SNAPSHOT_SCREENSHOT_FREQUENCY = 5000;
 export const DEFAULT_SNAPSHOT_RESIZE_OPTIONS = { width: 480, height: 360 };
 export const DEFAULT_SCREENSHOT_RESIZE_OPTIONS = { width: 480, height: 270 };
 export const MAX_EVENTS_BEFORE_SEND = 5;
-export const DEFAULT_HEADERS_CONTENT_TYPE = 'application/x-www-form-urlencoded';
+export const HEADER_CONTENT_TYPES = {
+  urlEncoded: 'application/x-www-form-urlencoded',
+  json: 'application/json',
+};
+export const BROWSER_BLUR_WARNING = 'Your test screen is not in focus. Please do not change your window or move your cursor outside the test screen. Doing so will lead to disqualification';


### PR DESCRIPTION
# Description
This PR includes:
- Addition of new header type
- Config default value remains same.

# Screenshots

## For content Type application/json
![Screenshot from 2024-11-19 13-34-53](https://github.com/user-attachments/assets/9f9fbb3c-3917-4680-a540-6e384729d0e8)

## For content type application/x-www-urlencoded
![Screenshot from 2024-11-19 13-33-59](https://github.com/user-attachments/assets/8b5e3070-0bf5-4697-99aa-843b237d1dc0)
