### PR TITLE
fix: detecting tab switches

### DIFF
--- a/src/utils/violations/tabSwitch.js
+++ b/src/utils/violations/tabSwitch.js
@@ -1,11 +1,10 @@
 import { VIOLATIONS } from '../constants';
 import { getIsBrowserBlurred } from './browserBlur';
 
-let visibilityChangeHandler = null;
-
 export default function detectTabSwitch(handleViolation) {
-  visibilityChangeHandler = () => {
-    if (document.hidden && !getIsBrowserBlurred()) {
+  const visibilityChangeHandler = () => {
+    const isBlurred = getIsBrowserBlurred();
+    if (document.hidden && !!isBlurred) {
       handleViolation(VIOLATIONS.tabSwitch);
     }
   };


### PR DESCRIPTION
fix for detecting tab switches and browser blurs separately.

Added a browser blur check in tabSwitch as, when window loses focus, tab also loses focus, to prevent browser blur to be detected as tab switch, added this check in the tabSwitch detection.

# screen recording : 
[Screencast from 21-11-24 01:12:20 AM IST.webm](https://github.com/user-attachments/assets/9b668e46-2560-4da1-bab6-f9db1508c505)
