### PR TITLE
update: Alert toast to 8sec, and fix reset timer while changing steps

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -244,7 +244,7 @@ const App = ({
       <ToastContainer
         position="top-center"
         toastClassName="text-base"
-        autoClose={5000}
+        autoClose={8000}
         hideProgressBar={false}
         newestOnTop={false}
         closeOnClick={false}

--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,8 @@ import Proctor from '@/proctor';
 import ScreenShareHandlers from '@/store/handlers/screenShare';
 import WebcamHandlers from '@/store/handlers/webcam';
 
+import { TOAST_AUTO_CLOSE_DURATION } from '@/utils/constants';
+
 import 'react-toastify/dist/ReactToastify.css';
 
 const App = ({
@@ -244,7 +246,7 @@ const App = ({
       <ToastContainer
         position="top-center"
         toastClassName="text-base"
-        autoClose={8000}
+        autoClose={TOAST_AUTO_CLOSE_DURATION}
         hideProgressBar={false}
         newestOnTop={false}
         closeOnClick={false}

--- a/src/components/DisqualificationTimerBar/DisqualificationTimerBar.tsx
+++ b/src/components/DisqualificationTimerBar/DisqualificationTimerBar.tsx
@@ -87,14 +87,18 @@ const DisqualificationTimerBar: React.FC<DisqualificationTimerBarProps> = ({
   };
 
   useEffect(() => {
+    // Only reset timer when modal opens or when failing steps change (getMaxTime changes)
     setTimeLeft(getMaxTime);
+  }, [modalOpen, getMaxTime]);
 
+  useEffect(() => {
+    // Handle audio separately to avoid timer reset on activeStep change
     if (beepConfig?.enabled && beepConfig.sounds && beepConfig.sounds[activeStep]) {
       handleAudio(beepConfig.sounds[activeStep]);
     }
 
     return stopAudio;
-  }, [modalOpen, getMaxTime, activeStep, beepConfig]);
+  }, [activeStep, beepConfig]);
 
   useEffect(() => {
     if (timeLeft <= 0) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -38,3 +38,4 @@ export const PAIRING_STEPS = {
 };
 
 export const MIN_SNAPSHOT_COUNT = 3;
+export const TOAST_AUTO_CLOSE_DURATION = 8000;


### PR DESCRIPTION
Description:
1. Toast Timer from 5sec -> 8sec
2. Disqualification Timer Was resetting while changing workflow steps. Why? Audio Change was in the same dependency array as when active steps changed.
The problem is that the timer should persist across workflow switches and only reset when the modal is first opened, not when switching between workflows.
Now I've fixed this issue by modifying the DisqualificationTimerBar component to not reset the timer when activeStep changes, but only when the modal opens or when there are changes to failing steps.
Also now, new use effect Handles the beep sounds separately when activeStep changes, without affecting the timer

https://github.com/user-attachments/assets/0b2eab4d-f78f-4a64-bd08-96a9cfa3dfec
